### PR TITLE
Add markdown README with updated content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,8 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Build artifacts
+artifact*.zip
+package
+

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ NOTE: This AWS Lambda Function is intended to be used as a cumulus task and this
 
 ## Help
 
-`This <https://chariotsolutions.com/blog/post/building-lambdas-with-poetry/>`_ page contains some good info on the overall "building a zip with poetry that's compatible with AWS Lambda".
+[This article](https://chariotsolutions.com/blog/post/building-lambdas-with-poetry) contains some good info on the overall "building a zip with poetry that's compatible with AWS Lambda".
 
 ## Version History
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,82 @@
+# cumulus-publish-cnm
+
+This is the Python code for the lambda `cumulus-publish-cnm`. It takes in a list of cnm's (Cloud Notification Mechanism) and publishes each one to the specified ingestion SNS (provider-input-sns)
+
+## Getting Started
+
+### Dependencies
+
+* [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer)
+* Optional: [pyenv](https://github.com/pyenv/pyenv) and [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv)
+
+### Installing
+
+* Option 1: Use `pyenv` to create a virtual environment and activate it
+
+        $ pyenv virtualenv 3.11.9 cumulus-publish-cnm
+        $ pyenv activate cumulus-publish-cnm
+        $ poetry shell
+
+* Option 2: Use Poetry to create and activate a virtual environment
+
+        $ poetry shell
+
+* Install dependencies
+
+        $ poetry install
+
+### Build
+
+        $ ./build.sh
+
+### Run Tests
+
+        $ poetry run pytest tests
+
+### Manual Build
+
+This command creates the `dist/` folder:
+
+        $ poetry build
+
+This command downloads the dependency files from the just created .whl file, along with the lambda_handler function in `cumulus_publish_cnm/cumulus_publish_cnm.py`, and places them in the `package` folder:
+
+        $ poetry run pip install --upgrade -t package dist/*.whl
+
+Note that **boto3** and **moto** are not being pulled in. I've specifically excluded them via having them as `tool.poetry.dev-dependencies` only (via the `pyproject.toml` file)
+
+The last command used is:
+
+        $ cd package ; zip -r ../artifact.zip . -x '*.pyc'
+
+Which zips and creates the `artifact.zip` file, containing all files found in `package/` excluding .pyc files
+
+
+### Running the Lambda
+
+Upload `artifact.zip` to any location you plan to use it
+
+* Upload directly as a lambda with `aws lambda update-function-code`
+* Upload to your AWS S3 `lambdas/` folder so that your Cumulus Terraform Build can use it
+
+NOTE: This AWS Lambda Function is intended to be used as a cumulus task and this requires `sns_endpoint` from the `task_config`:
+
+    "task_config": {
+        "sns_endpoint": "{$.meta.ingest_workflow_sns}"
+    }
+
+## Help
+
+`This <https://chariotsolutions.com/blog/post/building-lambdas-with-poetry/>`_ page contains some good info on the overall "building a zip with poetry that's compatible with AWS Lambda".
+
+## Version History
+
+See the [CHANGELOG](CHANGELOG.md)
+
+## License
+
+TBD
+
+## Acknowledgments
+
+Forked from PODAAC's [cumulus-publish-cnm](https://github.com/podaac/cumulus-publish-cnm) GitHub repo


### PR DESCRIPTION
Here's a markdown version of the README that also includes a little more context for getting started with the project as a developer. I pulled a simple README template from some site and populated it with what I thought would be helpful, largely pulling from the existing .rst file. Do we want to keep the README as .rst or should we move to .md? I can update this PR either way.